### PR TITLE
Add typings to package.json export

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "exports": {
     ".": {
       "import": "./dist/vue-stripe.es.js",
-      "require": "./dist/vue-stripe.umd.js"
+      "require": "./dist/vue-stripe.umd.js",
+      "types": "./types/vue-stripe.d.ts"
     }
   },
   "types": "./types/vue-stripe.d.ts",


### PR DESCRIPTION
When importing the package in a project made with [Vite](https://vitejs.dev/), eslint was complaining it could not find type definitions.
```
Could not find a declaration file for module 'vue-stripe-js'. 'projectdir/node_modules/vue-stripe-js/dist/vue-stripe.es.js' implicitly has an 'any' type.
  There are types at 'projectdir/node_modules/vue-stripe-js/types/vue-stripe.d.ts', but this result could not be resolved when respecting package.json "exports". The 'vue-stripe-js' library may need to update its package.json or typings.
```

This seems to be a related issue to https://github.com/microsoft/TypeScript/issues/52363 which can be fixed by adding the `types` property under `exports` in package.json.